### PR TITLE
cmake: eliminate duplicate static library link warnings

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
 		{
 			"label": "configure (dev-mode)",
 			"type": "shell",
-			"command": "cmake -S ${workspaceFolder} -B ${workspaceFolder}/build -DWERROR=ON -DWITH_USDT=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --preset dev-mode",
+			"command": "cmake -S ${workspaceFolder} -B ${workspaceFolder}/build -DWERROR=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --preset dev-mode",
 			"problemMatcher": ["$gcc"],
 			"group": {"kind": "build"}
 		},
@@ -26,7 +26,7 @@
 		{
 			"label": "configure (debug)",
 			"type": "shell",
-			"command": "cmake -S ${workspaceFolder} -B ${workspaceFolder}/build -DCMAKE_BUILD_TYPE=Debug -DWERROR=ON -DWITH_USDT=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --preset dev-mode",
+			"command": "cmake -S ${workspaceFolder} -B ${workspaceFolder}/build -DCMAKE_BUILD_TYPE=Debug -DWERROR=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --preset dev-mode",
 			"problemMatcher": ["$gcc"],
 			"group": "build"
 		},

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,9 +102,8 @@ if(BUILD_MINE)
   add_windows_application_manifest(sv2-tp)
   target_link_libraries(sv2-tp
     core_interface
-    bitcoin_common
     bitcoin_ipc
-    bitcoin_sv2
+    bitcoin_sv2 # bitcoin_common now transitively provided PUBLIC by bitcoin_sv2
   )
   install_binary_component(sv2-tp HAS_MANPAGE)
 endif()

--- a/src/sv2/CMakeLists.txt
+++ b/src/sv2/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(bitcoin_sv2
     core_interface
     bitcoin_clientversion
     bitcoin_crypto
-    bitcoin_common # for SockMan
     $<$<PLATFORM_ID:Windows>:ws2_32>
+  PUBLIC
+    bitcoin_common # for SockMan, expose to consumers so they need not link it explicitly
 )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -10,10 +10,14 @@ add_executable(test_sv2
 
 add_windows_application_manifest(test_sv2)
 
+# Link all required libraries in a single keyword-style invocation to avoid
+# mixing plain and keyword signatures (prevents duplicate library warnings too).
 target_link_libraries(test_sv2
-  core_interface
-  secp256k1
-  Boost::headers
+  PRIVATE
+    core_interface
+    Boost::headers
+    bitcoin_sv2
+    bitcoin_ipc
 )
 
 target_sources(test_sv2
@@ -29,7 +33,6 @@ PRIVATE
   sv2_template_provider_tests.cpp
   sv2_tester_lifecycle_tests.cpp
 )
-target_link_libraries(test_sv2 bitcoin_sv2 bitcoin_ipc)
 
 # Ensure Cap'n Proto generated headers (e.g. src/ipc/capnp/init.capnp.h) are
 # generated before compiling tests that include them directly.
@@ -45,7 +48,7 @@ if(TARGET Libmultiprocess::multiprocess)
   # test_sv2 directly includes generated IPC headers (init.capnp.h) which in turn
   # include libmultiprocess headers (mp/proxy.capnp.h). When using external
   # libmultiprocess, link the imported target to provide the necessary include paths.
-  target_link_libraries(test_sv2 Libmultiprocess::multiprocess)
+  target_link_libraries(test_sv2 PRIVATE Libmultiprocess::multiprocess)
 endif()
 
 function(add_boost_test source_file)

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -14,14 +14,12 @@ target_sources(fuzz
 )
 
 target_link_libraries(fuzz
-  core_interface
-  fuzzer_interface
-  bitcoin_common
-  bitcoin_util
-  bitcoin_sv2
-  secp256k1
-  Boost::headers
-  test_util
+  PRIVATE
+    core_interface
+    fuzzer_interface
+    bitcoin_sv2 # transitively provides bitcoin_common
+    Boost::headers
+    test_util
 )
 
 if(NOT FUZZ_BINARY_LINKS_WITHOUT_MAIN_FUNCTION)


### PR DESCRIPTION
First commit fixes and omission from #24.

The second fixes duplicate library link warnings.