### PR TITLE
sv2-tp: Add missing global sha2/rand init

### DIFF
--- a/src/sv2-tp.cpp
+++ b/src/sv2-tp.cpp
@@ -132,6 +132,9 @@ MAIN_FUNCTION
     }
 
     ECC_Context ecc_context{};
+    std::string sha256_algo = SHA256AutoDetect();
+    LogInfo("Using the '%s' SHA256 implementation\n", sha256_algo);
+    RandomInit();
 
     // Parse -sv2... params
     Sv2TemplateProviderOptions options{};


### PR DESCRIPTION
Additional logging with this included:
> 2025-10-07T16:44:10Z Using the 'x86_shani(1way,2way)' SHA256 implementation
> 2025-10-07T16:44:10Z Using RdSeed as an additional entropy source
> 2025-10-07T16:44:10Z Using RdRand as an additional entropy source

Otherwise, sha2 is the naive unoptimized impl, and random initialization happens later.